### PR TITLE
multiple code improvements: squid:S1068, squid:S2325

### DIFF
--- a/CustomDatepicker/src/main/java/org/wicketTutorial/datepicker/JQueryDateField.java
+++ b/CustomDatepicker/src/main/java/org/wicketTutorial/datepicker/JQueryDateField.java
@@ -17,8 +17,6 @@
 package org.wicketTutorial.datepicker;
 
 import java.util.Date;
-import java.util.HashMap;
-import java.util.Map;
 
 import org.apache.wicket.AttributeModifier;
 
@@ -27,16 +25,13 @@ import org.apache.wicket.extensions.markup.html.form.DateTextField;
 import org.apache.wicket.markup.head.CssHeaderItem;
 import org.apache.wicket.markup.head.IHeaderResponse;
 import org.apache.wicket.markup.head.JavaScriptHeaderItem;
-import org.apache.wicket.markup.head.OnDomReadyHeaderItem;
 import org.apache.wicket.markup.head.OnLoadHeaderItem;
-import org.apache.wicket.markup.head.StringHeaderItem;
 import org.apache.wicket.model.IModel;
 import org.apache.wicket.model.ResourceModel;
 import org.apache.wicket.request.mapper.parameter.PageParameters;
 import org.apache.wicket.request.resource.PackageResourceReference;
 import org.apache.wicket.settings.JavaScriptLibrarySettings;
 import org.apache.wicket.util.convert.IConverter;
-import org.apache.wicket.util.template.PackageTextTemplate;
 
 public class JQueryDateField extends DateTextField {
 
@@ -47,7 +42,6 @@ public class JQueryDateField extends DateTextField {
 	private PatternDateConverter dateConverter;
 	private String datePattern;
 	private String countryIsoCode;
-	private String jQueryCalendar;
 	private CharSequence urlForIcon;
 	private static final PackageResourceReference JQDatePickerRef = 
 						   new PackageResourceReference(JQueryDateField.class, "JQDatePicker.js");

--- a/CustomDatepickerAjax/src/main/java/org/wicketTutorial/ajaxdatepicker/JQueryDateFieldAjax.java
+++ b/CustomDatepickerAjax/src/main/java/org/wicketTutorial/ajaxdatepicker/JQueryDateFieldAjax.java
@@ -17,8 +17,6 @@
 package org.wicketTutorial.ajaxdatepicker;
 
 import java.util.Date;
-import java.util.HashMap;
-import java.util.Map;
 
 import org.apache.wicket.AttributeModifier;
 
@@ -27,16 +25,13 @@ import org.apache.wicket.extensions.markup.html.form.DateTextField;
 import org.apache.wicket.markup.head.CssHeaderItem;
 import org.apache.wicket.markup.head.IHeaderResponse;
 import org.apache.wicket.markup.head.JavaScriptHeaderItem;
-import org.apache.wicket.markup.head.OnDomReadyHeaderItem;
 import org.apache.wicket.markup.head.OnLoadHeaderItem;
-import org.apache.wicket.markup.head.StringHeaderItem;
 import org.apache.wicket.model.IModel;
 import org.apache.wicket.model.ResourceModel;
 import org.apache.wicket.request.mapper.parameter.PageParameters;
 import org.apache.wicket.request.resource.PackageResourceReference;
 import org.apache.wicket.settings.JavaScriptLibrarySettings;
 import org.apache.wicket.util.convert.IConverter;
-import org.apache.wicket.util.template.PackageTextTemplate;
 
 public class JQueryDateFieldAjax extends DateTextField {
 
@@ -47,7 +42,6 @@ public class JQueryDateFieldAjax extends DateTextField {
 	private PatternDateConverter dateConverter;
 	private String datePattern;
 	private String countryIsoCode;
-	private String jQueryCalendar;
 	private CharSequence urlForIcon;
 	private static final PackageResourceReference JQDatePickerRef = 
 						   new PackageResourceReference(JQueryDateFieldAjax.class, "JQDatePicker.js");

--- a/JpaLodableModel/src/main/java/org/wicketTutorial/hibernatemodel/model/JpaLoadableModel.java
+++ b/JpaLodableModel/src/main/java/org/wicketTutorial/hibernatemodel/model/JpaLoadableModel.java
@@ -17,7 +17,6 @@
 package org.wicketTutorial.hibernatemodel.model;
 
 import java.io.Serializable;
-import java.util.List;
 
 import javax.persistence.EntityManager;
 import javax.persistence.EntityManagerFactory;
@@ -30,7 +29,6 @@ public class JpaLoadableModel<T> extends LoadableDetachableModel<T> {
 	private EntityManagerFactory entityManagerFactory;
 	private Class<T> entityClass;
 	private Serializable identifier;
-	private List<Object> constructorParams;
 	
 	public JpaLoadableModel(EntityManagerFactory entityManagerFactory, T entity) {
 		super();

--- a/ModelChainingExample/src/main/java/org/wicketTutorial/modelchain/PersonListDetails.java
+++ b/ModelChainingExample/src/main/java/org/wicketTutorial/modelchain/PersonListDetails.java
@@ -23,7 +23,6 @@ import org.apache.wicket.markup.html.WebPage;
 import org.apache.wicket.markup.html.form.ChoiceRenderer;
 import org.apache.wicket.markup.html.form.DropDownChoice;
 import org.apache.wicket.markup.html.form.Form;
-import org.apache.wicket.markup.html.form.IChoiceRenderer;
 import org.apache.wicket.markup.html.form.TextField;
 import org.apache.wicket.model.CompoundPropertyModel;
 import org.apache.wicket.model.Model;
@@ -59,7 +58,7 @@ public class PersonListDetails extends WebPage {
 		add(form);
 	}
 	
-	private List<Person> personsPojo() {
+	private static List<Person> personsPojo() {
 		List<Person> persons = new ArrayList<Person>();
 		Person person = new Person("John", "Smith");
 		

--- a/MountedPagesExample/src/main/java/org/tutorialWicket/mountedpages/MountedPage.java
+++ b/MountedPagesExample/src/main/java/org/tutorialWicket/mountedpages/MountedPage.java
@@ -18,11 +18,9 @@ package org.tutorialWicket.mountedpages;
 
 import org.apache.wicket.markup.html.WebPage;
 import org.apache.wicket.markup.html.link.Link;
-import org.apache.wicket.markup.html.link.StatelessLink;
 import org.apache.wicket.request.mapper.parameter.PageParameters;
 
 public class MountedPage extends WebPage {
-	private int index = 0;
 	public MountedPage() {
 		super();
 		


### PR DESCRIPTION
This pull request is focused on resolving occurrence of Sonar rules
squid:S1068 - Unused private fields should be removed.
squid:S2325 - "private" methods that don't access instance data should be "static".
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1068
https://dev.eclipse.org/sonar/rules/show/squid:S2325
https://dev.eclipse.org/sonar/rules/show/squid:UselessImportCheck
Please let me know if you have any questions.
George Kankava