### PR TITLE
multiple code improvements: squid:AssignmentInSubExpressionCheck, squid:S1213

### DIFF
--- a/CustomConverter/src/main/java/org/wicketTutorial/customconverter/HomePage.java
+++ b/CustomConverter/src/main/java/org/wicketTutorial/customconverter/HomePage.java
@@ -51,8 +51,10 @@ public class HomePage extends WebPage {
 		};
     	
 		form.setDefaultModel(new CompoundPropertyModel(this));
-		form.add(mail = new TextField("regExpPatter"));
-		form.add(stringToSplitTxt = new TextField("stringToSplit"));
+		mail = new TextField("regExpPatter");
+		form.add(mail);
+		stringToSplitTxt = new TextField("stringToSplit");
+		form.add(stringToSplitTxt);
 		add(new FeedbackPanel("feedbackMessage").setEscapeModelStrings(false));
 		
 		add(form);

--- a/CustomDatepicker/src/main/java/org/wicketTutorial/datepicker/JQueryDateField.java
+++ b/CustomDatepicker/src/main/java/org/wicketTutorial/datepicker/JQueryDateField.java
@@ -45,17 +45,17 @@ public class JQueryDateField extends DateTextField {
 	private CharSequence urlForIcon;
 	private static final PackageResourceReference JQDatePickerRef = 
 						   new PackageResourceReference(JQueryDateField.class, "JQDatePicker.js");
-	 
-	public String getDatePattern() {
-		return datePattern;
+	
+	public JQueryDateField(String id){
+		super(id);
 	}
 	
 	public JQueryDateField(String id, IModel<Date> dateModel){
 		super(id, dateModel);	
 	}
 	
-	public JQueryDateField(String id){
-		super(id);
+	public String getDatePattern() {
+		return datePattern;
 	}
 	
 	@Override

--- a/CustomDatepickerAjax/src/main/java/org/wicketTutorial/ajaxdatepicker/HomePage.java
+++ b/CustomDatepickerAjax/src/main/java/org/wicketTutorial/ajaxdatepicker/HomePage.java
@@ -36,7 +36,8 @@ public class HomePage extends WebPage {
 		super(parameters);
 		Form form = new Form("form");
 		final JQueryDateFieldAjax datepicker;
-		form.add(datepicker = new JQueryDateFieldAjax("datepicker", new Model<Date>()));
+		datepicker = new JQueryDateFieldAjax("datepicker", new Model<Date>());
+		form.add(datepicker);
 		
 		add(new AjaxLink("update"){
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules
squid:AssignmentInSubExpressionCheck Assignments should not be made from within sub-expressions,
squid:S1213 The members of an interface declaration or class should appear in a pre-defined order.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/coding_rules#q=squid%3AAssignmentInSubExpressionCheck,
https://dev.eclipse.org/sonar/coding_rules#q=squid%3AS1213
Please let me know if you have any questions.
George Kankava