### PR TITLE
Multiple code improvements: squid:S00105, squid:S1213

### DIFF
--- a/StringResourceModelExample/src/main/java/com/mycompany/HomePage.java
+++ b/StringResourceModelExample/src/main/java/com/mycompany/HomePage.java
@@ -25,10 +25,10 @@ import org.apache.wicket.model.Model;
 import org.apache.wicket.model.StringResourceModel;
 
 public class HomePage extends WebPage {
-	private static final long serialVersionUID = 1L;
+    private static final long serialVersionUID = 1L;
 
     public HomePage(final PageParameters parameters) {
-    	Order order = new Order(new Date(), ORDER_STATUS.IN_PROGRESS);
-		add(new Label("orderStatus", new StringResourceModel("orderStatus.${status.code}", Model.of(order))));    
+        Order order = new Order(new Date(), ORDER_STATUS.IN_PROGRESS);
+        add(new Label("orderStatus", new StringResourceModel("orderStatus.${status.code}", Model.of(order))));    
     }
 }

--- a/StringResourceModelExample/src/main/java/com/mycompany/ORDER_STATUS.java
+++ b/StringResourceModelExample/src/main/java/com/mycompany/ORDER_STATUS.java
@@ -17,18 +17,19 @@
 package com.mycompany;
 
 public enum ORDER_STATUS {
-	PAYMENT_ACCEPTED(0),
-	IN_PROGRESS(1),
-	SHIPPING(2),
-	DELIVERED(3);
-	
-	private int code;
-	
-	public int getCode() {
-		return code;
-	}
+    PAYMENT_ACCEPTED(0),
+    IN_PROGRESS(1),
+    SHIPPING(2),
+    DELIVERED(3);
+    
+    private int code;
+    
+    private ORDER_STATUS(int code){
+        this.code = code;
+    }
+    
+    public int getCode() {
+        return code;
+    }
 
-	private ORDER_STATUS(int code){
-		this.code = code;
-	}
 }

--- a/StringResourceModelExample/src/main/java/com/mycompany/Order.java
+++ b/StringResourceModelExample/src/main/java/com/mycompany/Order.java
@@ -20,20 +20,21 @@ import java.io.Serializable;
 import java.util.Date;
 
 public class Order implements Serializable{
-	private Date orderDate;
-	private ORDER_STATUS status;
-	
-	public Date getOrderDate() {
-		return orderDate;
-	}
+    private Date orderDate;
+    private ORDER_STATUS status;
+    
+    public Order(Date orderDate, ORDER_STATUS status) {
+        super();
+        this.orderDate = orderDate;
+        this.status = status;
+    }
 
-	public ORDER_STATUS getStatus() {
-		return status;
-	}
+    public Date getOrderDate() {
+        return orderDate;
+    }
 
-	public Order(Date orderDate, ORDER_STATUS status) {
-		super();
-		this.orderDate = orderDate;
-		this.status = status;
-	}
+    public ORDER_STATUS getStatus() {
+        return status;
+    }
+
 }

--- a/StringResourceModelExample/src/main/java/com/mycompany/WicketApplication.java
+++ b/StringResourceModelExample/src/main/java/com/mycompany/WicketApplication.java
@@ -24,24 +24,24 @@ import org.apache.wicket.protocol.http.WebApplication;
  * @see com.mycompany.Start#main(String[])
  */
 public class WicketApplication extends WebApplication
-{    	
-	/**
-	 * @see org.apache.wicket.Application#getHomePage()
-	 */
-	@Override
-	public Class<HomePage> getHomePage()
-	{
-		return HomePage.class;
-	}
+{        
+    /**
+     * @see org.apache.wicket.Application#getHomePage()
+     */
+    @Override
+    public Class<HomePage> getHomePage()
+    {
+        return HomePage.class;
+    }
 
-	/**
-	 * @see org.apache.wicket.Application#init()
-	 */
-	@Override
-	public void init()
-	{
-		super.init();
+    /**
+     * @see org.apache.wicket.Application#init()
+     */
+    @Override
+    public void init()
+    {
+        super.init();
 
-		// add your configuration here
-	}
+        // add your configuration here
+    }
 }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules
squid:S00105 - Tabulation characters should not be used.
squid:S1213 - The members of an interface declaration or class should appear in a pre-defined order.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S00105
https://dev.eclipse.org/sonar/rules/show/squid:S1213
Please let me know if you have any questions.
George Kankava