### PR TITLE
multiple code improvements: squid:AssignmentInSubExpressionCheck, squid:S1213, squid:ClassVariableVisibilityCheck, squid:RightCurlyBraceStartLineCheck

### DIFF
--- a/CustomDatepickerAjax/src/main/java/org/wicketTutorial/ajaxdatepicker/JQueryDateFieldAjax.java
+++ b/CustomDatepickerAjax/src/main/java/org/wicketTutorial/ajaxdatepicker/JQueryDateFieldAjax.java
@@ -45,10 +45,6 @@ public class JQueryDateFieldAjax extends DateTextField {
 	private CharSequence urlForIcon;
 	private static final PackageResourceReference JQDatePickerRef = 
 						   new PackageResourceReference(JQueryDateFieldAjax.class, "JQDatePicker.js");
-	 
-	public String getDatePattern() {
-		return datePattern;
-	}
 	
 	public JQueryDateFieldAjax(String id, IModel<Date> dateModel){
 		super(id, dateModel);	
@@ -56,6 +52,10 @@ public class JQueryDateFieldAjax extends DateTextField {
 	
 	public JQueryDateFieldAjax(String id){
 		super(id);
+	}
+	 
+	public String getDatePattern() {
+		return datePattern;
 	}
 	
 	@Override

--- a/CustomFormComponentPanel/src/main/java/org/wicketTutorial/formpanel/TemperatureDegreeField.java
+++ b/CustomFormComponentPanel/src/main/java/org/wicketTutorial/formpanel/TemperatureDegreeField.java
@@ -53,7 +53,8 @@ public class TemperatureDegreeField extends FormComponentPanel<Double> {
 		};
 		
 		add(new Label("mesuramentUnit", labelModel));
-		add(userDegree = new TextField<Double>("registeredTemperature", new Model<Double>()));
+		userDegree = new TextField<Double>("registeredTemperature", new Model<Double>());
+		add(userDegree);
 		userDegree.setType(Double.class);
 	}
 	

--- a/CustomResourceMounting/src/main/java/org/wicketTutorial/resmounting/WicketApplication.java
+++ b/CustomResourceMounting/src/main/java/org/wicketTutorial/resmounting/WicketApplication.java
@@ -48,7 +48,8 @@ public class WicketApplication extends WebApplication
 			@Override
 			public IResource getResource() {
 				return deviceMetaResource;
-			}};
+			}
+		};
 			
 		mountResource("/foo/bar", resourceReference);
 		mountResource("/bar/${baz}", resourceReference);

--- a/EjbInjectionExample/src/main/java/org/wicketTutorial/ejbinjection/ejbBean/EnterpriseMessage.java
+++ b/EjbInjectionExample/src/main/java/org/wicketTutorial/ejbinjection/ejbBean/EnterpriseMessage.java
@@ -20,5 +20,5 @@ import javax.enterprise.context.ApplicationScoped;
 
 @ApplicationScoped
 public class EnterpriseMessage {
-	public String message = "Welcome to the EJB world!";
+	public static final String message = "Welcome to the EJB world!";
 }

--- a/InterComponetsEventsExample/src/main/java/org/wicketTutorial/eventinfra/HomePage.java
+++ b/InterComponetsEventsExample/src/main/java/org/wicketTutorial/eventinfra/HomePage.java
@@ -51,8 +51,8 @@ public class HomePage extends WebPage {
 		
 		add(containerInTheMiddle);
 		containerInTheMiddle.add(innerContainer);
-		FeedbackPanel feedbackPanel;
-		add(feedbackPanel = new FeedbackPanel("feedbackPanel"));		
+		FeedbackPanel feedbackPanel = new FeedbackPanel("feedbackPanel");
+		add(feedbackPanel);
 		
 		StatelessLink breadthLink = new StatelessLink("breadthLink") {
 

--- a/ListViewExample/src/main/java/org/wicketTutorial/listview/Person.java
+++ b/ListViewExample/src/main/java/org/wicketTutorial/listview/Person.java
@@ -28,14 +28,14 @@ public class Person implements Serializable {
 	
 	private Person spouse;
 	private List<Person> children;
-       
-	public String getFullName(){
-	   return name + " " + surname;
-	}
-	
+
 	public Person(String name, String surname) {
 		this.name = name;
 		this.surname = surname;
+	}
+
+	public String getFullName(){
+	   return name + " " + surname;
 	}
 
 	public String getName() {

--- a/MarkupInheritanceExample/src/main/java/org/wicketTutorial/markupinherit/layoutTenda/JugTemplate.java
+++ b/MarkupInheritanceExample/src/main/java/org/wicketTutorial/markupinherit/layoutTenda/JugTemplate.java
@@ -28,9 +28,12 @@ public class JugTemplate extends WebPage {
 	private Component footerPanel;
  
     public JugTemplate(){
-		add(headerPanel = new HeaderPanel("headerPanel"));
-		add(menuPanel = new MenuPanel("menuPanel"));
-		add(footerPanel = new FooterPanel("footerPanel"));
+		headerPanel = new HeaderPanel("headerPanel");
+		menuPanel = new MenuPanel("menuPanel");
+		footerPanel = new FooterPanel("footerPanel");
+		add(headerPanel);
+		add(menuPanel);
+		add(footerPanel);
 		add(new Label(CONTENT_ID, "Put your content here"));
 	}
     //getters for layout areas

--- a/OverrideMailMessage/src/main/java/org/wicketTutorial/overridemessage/HomePage.java
+++ b/OverrideMailMessage/src/main/java/org/wicketTutorial/overridemessage/HomePage.java
@@ -31,9 +31,9 @@ public class HomePage extends WebPage {
 
     public HomePage(final PageParameters parameters) {
 		Form form = new Form("form");
-		TextField mail;
+		TextField mail = new TextField("email", Model.of(""));
 		
-		form.add(mail = new TextField("email", Model.of("")));
+		form.add(mail);
 		mail.add(EmailAddressValidator.getInstance());
 		
 		add(new FeedbackPanel("feedbackMessage"));

--- a/SpringInjectionExample/src/main/java/org/wicketTutorial/springinjection/ejbBean/EnterpriseMessage.java
+++ b/SpringInjectionExample/src/main/java/org/wicketTutorial/springinjection/ejbBean/EnterpriseMessage.java
@@ -22,5 +22,5 @@ import org.springframework.stereotype.Service;
 
 @ManagedBean
 public class EnterpriseMessage {
-	public String message = "Welcome to the Spring world!";
+	public static final String message = "Welcome to the Spring world!";
 }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules
squid:AssignmentInSubExpressionCheck Assignments should not be made from within sub-expressions.
squid:S1213 The members of an interface declaration or class should appear in a pre-defined order.
squid:ClassVariableVisibilityCheck Class variable fields should not have public accessibility.
squid:RightCurlyBraceStartLineCheck A close curly brace should be located at the beginning of a line.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/coding_rules#q=squid%3AS00105
https://dev.eclipse.org/sonar/coding_rules#q=squid%3AAssignmentInSubExpressionCheck
https://dev.eclipse.org/sonar/coding_rules#q=squid%3AS1213
https://dev.eclipse.org/sonar/coding_rules#q=squid%3AClassVariableVisibilityCheck
https://dev.eclipse.org/sonar/coding_rules#q=squid%3ARightCurlyBraceStartLineCheck
Please let me know if you have any questions.
George Kankava